### PR TITLE
Fix assertion on main gui editor painting

### DIFF
--- a/General/foleys_MagicPluginEditor.cpp
+++ b/General/foleys_MagicPluginEditor.cpp
@@ -72,11 +72,6 @@ void MagicPluginEditor::restoreGUI (const juce::ValueTree& gui)
     builder.restoreGUI (gui);
 }
 
-void MagicPluginEditor::resized()
-{
-    builder.updateLayout();
-}
-
 void MagicPluginEditor::restoreGUI (const char* data, const int dataSize)
 {
     juce::String text (data, dataSize);
@@ -87,6 +82,16 @@ void MagicPluginEditor::restoreGUI (const char* data, const int dataSize)
 void MagicPluginEditor::createDefaultGUI (bool keepExisting)
 {
     builder.createDefaultGUITree (keepExisting);
+}
+
+void MagicPluginEditor::paint (juce::Graphics& g)
+{
+    g.fillAll (juce::Colours::black);
+}
+
+void MagicPluginEditor::resized()
+{
+    builder.updateLayout();
 }
 
 } // namespace foleys

--- a/General/foleys_MagicPluginEditor.h
+++ b/General/foleys_MagicPluginEditor.h
@@ -72,6 +72,8 @@ public:
 
     void createDefaultGUI (bool keepExisting);
 
+    void paint (juce::Graphics& g) override;
+
     void resized() override;
 
 private:


### PR DESCRIPTION
This pull request fixes the assertion thrown by Juce for the `MagicPluginEditor` class not implementing the `paint (juce::Graphics& g)` method. I also moved the `resized()` method further down in the .cpp file so it looks consistent with the header.