### PR TITLE
Changed Container's resized method to use Juce's flexbox layout

### DIFF
--- a/Layout/foleys_Container.cpp
+++ b/Layout/foleys_Container.cpp
@@ -46,28 +46,13 @@ void Container::resized()
     if (children.empty())
         return;
 
-    auto bounds = getClientBounds();
+    juce::FlexBox fb;
+    fb.flexDirection = (layout == Layout::HorizontalBox)? juce::FlexBox::Direction::row : juce::FlexBox::Direction::column;
 
-    if (layout == Layout::HorizontalBox)
-    {
-        int w = bounds.getWidth() / children.size();
+    for (auto& child : children)
+        fb.items.add (juce::FlexItem (*child).withFlex (1.0f));
 
-        for (auto& child : children)
-            child->setBounds (bounds.removeFromLeft (w));
-    }
-    else if (layout == Layout::VerticalBox)
-    {
-        int h = bounds.getHeight() / children.size();
-
-        for (auto& child : children)
-            child->setBounds (bounds.removeFromTop (h));
-    }
-    else
-    {
-        for (auto& child : children)
-            child->setBounds (bounds);
-    }
-
+    fb.performLayout (getLocalBounds());
 }
 
 } // namespace foleys


### PR DESCRIPTION
(very) early implementation of the FlexBox layout on the Container, it'll give us more flexibility in the future. Performance is definitely not great, we should investigate if making all the layout calculations in the Editor would be faster/be better/make more sense than in each component