### PR TITLE
Implemented GUITreeEditor component

### DIFF
--- a/Editor/foleys_GUITreeEditor.cpp
+++ b/Editor/foleys_GUITreeEditor.cpp
@@ -27,28 +27,61 @@
  ==============================================================================
  */
 
-
 namespace foleys
 {
 
 GUITreeEditor::GUITreeEditor (MagicBuilder& builderToEdit)
-  : builder (builderToEdit)
+  : builder (builderToEdit), tree (builderToEdit.getGuiTree())
 {
+    tree.addListener (this);
+    treeView.setRootItemVisible (false);
+    treeView.setMultiSelectEnabled (false);
+
+    addNode.setEnabled (false);
+    addNode.onClick = [&]
+    {
+        // Show popup with types of nodes to add to the ValueTree: div, slider, button, etc
+        // add new node as a child of the currently selected node
+    };
+
+    removeNode.onClick = [&]
+    {
+        if (GUITreeEditor::GuiTreeItem* selectedItem = static_cast<GUITreeEditor::GuiTreeItem*> (treeView.getSelectedItem (0)))
+        {
+            juce::ValueTree& tree = selectedItem->getTree();
+            tree.getParent().removeChild (tree, nullptr);
+        }
+    };
+
+    treeView.setRootItem (nullptr);
+    rootItem = std::make_unique<GUITreeEditor::GuiTreeItem> (*this, tree);
+    treeView.setRootItem (rootItem.get());
+
+    addAndMakeVisible (treeView);
+    addAndMakeVisible (addNode);
+    addAndMakeVisible (removeNode);
 }
 
-void GUITreeEditor::paint (juce::Graphics& g)
-{
-    g.setColour (juce::Colours::silver);
-    g.drawRect (getLocalBounds(), 1);
-    g.setColour (juce::Colours::white);
-    g.drawFittedText (TRANS ("GUI tree"), 2, 2, getWidth() - 4, 20, juce::Justification::centred, 1);
-}
+//#include "../JuceLibraryCode/JuceHeader.h"
 
 void GUITreeEditor::resized()
 {
     auto bounds = getLocalBounds().reduced (1);
-    bounds.removeFromTop (24);
     treeView.setBounds (bounds);
+
+    auto bottomBarBounds = bounds.removeFromBottom (24).reduced (10, 0);
+    removeNode.setBounds (bottomBarBounds.removeFromRight (24));
+    addNode   .setBounds (bottomBarBounds.removeFromRight (24));
+}
+
+void GUITreeEditor::setValueTree (juce::ValueTree& refTree)
+{
+    tree = refTree;
+    tree.addListener (this);
+
+    treeView.setRootItem (nullptr);
+    rootItem = std::make_unique<GUITreeEditor::GuiTreeItem> (*this, tree);
+    treeView.setRootItem (rootItem.get());
 }
 
 void GUITreeEditor::valueTreePropertyChanged (juce::ValueTree& treeWhosePropertyHasChanged,
@@ -74,6 +107,59 @@ void GUITreeEditor::valueTreeChildOrderChanged (juce::ValueTree& parentTreeWhose
 
 void GUITreeEditor::valueTreeParentChanged (juce::ValueTree& treeWhoseParentHasChanged)
 {
+}
+
+GUITreeEditor::GuiTreeItem::GuiTreeItem (GUITreeEditor& refGuiTreeEditor, juce::ValueTree& refValueTree)
+    : guiTreeEditor {refGuiTreeEditor}, tree {refValueTree}
+{
+}
+
+juce::String GUITreeEditor::GuiTreeItem::getUniqueName() const
+{
+    return tree.getType().toString();
+}
+
+bool GUITreeEditor::GuiTreeItem::mightContainSubItems()
+{
+    return tree.getNumChildren() > 0;
+}
+
+void GUITreeEditor::GuiTreeItem::paintItem (juce::Graphics& g, int width, int height)
+{
+    if (isSelected())
+        g.fillAll ({91, 103, 109});
+
+    g.setColour (juce::Colours::white);
+    g.setFont (height * 0.7f);
+
+    juce::String s = tree.getType().toString();
+
+    juce::String ss = tree["caption"].toString();
+    if (!ss.isEmpty())
+        s << " - " << ss;
+
+    g.drawText (s, 4, 0, width - 4, height, juce::Justification::centredLeft, true);
+}
+
+void GUITreeEditor::GuiTreeItem::itemOpennessChanged (bool isNowOpen)
+{
+    if (isNowOpen)
+    {
+        if (getNumSubItems() == 0)
+        {
+            for (auto child : tree)
+                addSubItem (new GuiTreeItem (guiTreeEditor, child));
+        }
+    }
+}
+
+void GUITreeEditor::GuiTreeItem::itemSelectionChanged (bool isNowSelected)
+{
+    if (isNowSelected)
+    {
+        if (guiTreeEditor.onSelectionChanged != nullptr)
+            guiTreeEditor.onSelectionChanged (tree);
+    }
 }
 
 

--- a/Editor/foleys_GUITreeEditor.h
+++ b/Editor/foleys_GUITreeEditor.h
@@ -40,10 +40,37 @@ class GUITreeEditor  : public juce::Component,
 public:
     GUITreeEditor (MagicBuilder& builder);
 
-    void paint (juce::Graphics&) override;
     void resized() override;
 
+    void setValueTree (juce::ValueTree& refTree);
+
+    std::function<void (juce::ValueTree&)> onSelectionChanged {nullptr};
+
+
 private:
+    class GuiTreeItem : public juce::TreeViewItem
+    {
+    public:
+        GuiTreeItem (GUITreeEditor& refGuiTreeEditor, juce::ValueTree& refValueTree);
+
+        juce::String getUniqueName() const override;
+
+        bool mightContainSubItems() override;
+
+        void paintItem (juce::Graphics& g, int width, int height) override;
+
+        void itemOpennessChanged (bool isNowOpen) override;
+        void itemSelectionChanged (bool isNowSelected) override;
+
+        juce::ValueTree& getTree () { return tree; }
+
+    private:
+        GUITreeEditor& guiTreeEditor;
+        juce::ValueTree tree;
+
+        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (GuiTreeItem)
+    };
+
 
     void valueTreePropertyChanged (juce::ValueTree& treeWhosePropertyHasChanged,
                                    const juce::Identifier& property) override;
@@ -61,10 +88,14 @@ private:
     void valueTreeParentChanged (juce::ValueTree& treeWhoseParentHasChanged) override;
 
 
-    MagicBuilder&                       builder;
+    MagicBuilder&                builder;
+    juce::ValueTree              tree;
 
-    std::unique_ptr<juce::TreeViewItem> rootItem;
-    juce::TreeView                      treeView;
+    std::unique_ptr<GuiTreeItem> rootItem;
+    juce::TreeView               treeView;
+
+    juce::TextButton addNode    { TRANS ("+") };
+    juce::TextButton removeNode { TRANS ("X") };
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (GUITreeEditor)
 };

--- a/Editor/foleys_PropertiesEditor.cpp
+++ b/Editor/foleys_PropertiesEditor.cpp
@@ -90,6 +90,12 @@ void PropertiesEditor::setStyle (juce::ValueTree styleToEdit)
     style.addListener (this);
 }
 
+void PropertiesEditor::setNodeToEdit (juce::ValueTree node)
+{
+    propertiesModel.setNodeToEdit (node);
+    propertiesList.updateContent();
+}
+
 void PropertiesEditor::updatePopupMenu()
 {
     nodeSelect.clear();

--- a/Editor/foleys_PropertiesEditor.h
+++ b/Editor/foleys_PropertiesEditor.h
@@ -42,6 +42,8 @@ public:
 
     void setStyle (juce::ValueTree style);
 
+    void setNodeToEdit (juce::ValueTree node);
+
     void paint (juce::Graphics&) override;
     void resized() override;
 

--- a/Editor/foleys_ToolBox.cpp
+++ b/Editor/foleys_ToolBox.cpp
@@ -62,6 +62,11 @@ ToolBox::ToolBox (juce::Component* parentToUse, MagicBuilder& builderToControl)
         }
     };
 
+    treeEditor.onSelectionChanged = [&] (juce::ValueTree& ref)
+    {
+        propertiesEditor.setNodeToEdit (ref);
+    };
+
     loadXml.onClick = [&]
     {
         juce::FileChooser myChooser ("Load from XML file...", getLastLocation(), "*.xml");
@@ -72,7 +77,13 @@ ToolBox::ToolBox (juce::Component* parentToUse, MagicBuilder& builderToControl)
             auto tree = juce::ValueTree::fromXml (stream.readEntireStreamAsString());
 
             if (tree.isValid() && tree.getType() == IDs::magic)
+            {
                 builder.restoreGUI (tree);
+                builder.updateAll();
+
+                treeEditor.setValueTree (tree);
+                propertiesEditor.setStyle (builder.getStylesheet().getCurrentStyle());
+            }
 
             lastLocation = xmlFile;
         }


### PR DESCRIPTION
It takes a reference (that can be updated) to a `ValueTree` and displays its nodes in a visual tree structure. Removing nodes from the tree propagates the changes to the tree's listeners, and the component also has the `onSelectionChanged` callback, that I used to trigger an update on the `PropertiesEditor`, so we can also edit node's properties from there.
