### PR TITLE
check for if plot needs resizing

### DIFF
--- a/Visualisers/foleys_MagicAnalyser.cpp
+++ b/Visualisers/foleys_MagicAnalyser.cpp
@@ -46,8 +46,8 @@ void MagicAnalyser::drawPlot (juce::Graphics& g, juce::Rectangle<float> bounds, 
 {
     const float minFreq = 20.0f;
     const auto& data = analyserJob.getAnalyserData();
-
-    if (pathNeedsUpdate.load())
+    
+    if (pathNeedsUpdate.load() || checkPlotNeedsResizing())
     {
         path.clear();
         path.preallocateSpace (8 + data.getNumSamples() * 3);

--- a/Visualisers/foleys_MagicFilterPlot.cpp
+++ b/Visualisers/foleys_MagicFilterPlot.cpp
@@ -86,7 +86,7 @@ void MagicFilterPlot::pushSamples (const juce::AudioBuffer<float>&){}
 
 void MagicFilterPlot::drawPlot (juce::Graphics& g, juce::Rectangle<float> bounds, MagicPlotComponent& component)
 {
-    if (plotChanged || lastBounds != bounds)
+    if (plotChanged || checkPlotNeedsResizing())
     {
         const juce::ScopedReadLock readLock (plotLock);
 
@@ -98,8 +98,7 @@ void MagicFilterPlot::drawPlot (juce::Graphics& g, juce::Rectangle<float> bounds
         for (size_t i=1; i < frequencies.size(); ++i)
             path.lineTo (float (bounds.getX() + i * xFactor),
                          float (magnitudes [i] > 0 ? bounds.getCentreY() - yFactor * std::log (magnitudes [i]) / std::log (2) : bounds.getBottom()));
-
-        lastBounds  = bounds;
+        
         plotChanged = false;
     }
 

--- a/Visualisers/foleys_MagicFilterPlot.h
+++ b/Visualisers/foleys_MagicFilterPlot.h
@@ -82,7 +82,6 @@ private:
     juce::ReadWriteLock     plotLock;
     bool                    plotChanged = true;
     juce::Path              path;
-    juce::Rectangle<float>  lastBounds;
 
     std::vector<double>     frequencies;
     std::vector<double>     magnitudes;

--- a/Visualisers/foleys_MagicPlotSource.cpp
+++ b/Visualisers/foleys_MagicPlotSource.cpp
@@ -58,6 +58,11 @@ void MagicPlotSource::strokePlotPath (juce::Graphics& g, const juce::Path& path,
     g.strokePath (path, juce::PathStrokeType (2.0f));
 }
 
-
+bool MagicPlotSource::checkPlotNeedsResizing()
+{
+    auto flag = needsResizing;
+    needsResizing = false;
+    return flag;
+}
 
 }

--- a/Visualisers/foleys_MagicPlotSource.h
+++ b/Visualisers/foleys_MagicPlotSource.h
@@ -95,9 +95,20 @@ public:
      and it will automatically be added to the common background thread.
      */
     virtual juce::TimeSliceClient* getBackgroundJob() { return nullptr; }
+    
+    /**
+     Notifies the plot that it has been resized and may need redrawing.
+     */
+    void alertResized() { needsResizing = true; }
+    
+    /**
+     Gets and disables the needsResizing flag.
+     */
+    bool checkPlotNeedsResizing();
 
 private:
     bool active = true;
+    bool needsResizing = false;
     juce::Path filledPath;
 
     JUCE_DECLARE_WEAK_REFERENCEABLE (MagicPlotSource)

--- a/Widgets/foleys_MagicPlotComponent.cpp
+++ b/Widgets/foleys_MagicPlotComponent.cpp
@@ -105,6 +105,8 @@ void MagicPlotComponent::updateGlowBufferSize()
 void MagicPlotComponent::resized()
 {
     updateGlowBufferSize();
+    if (plotSource != nullptr)
+        plotSource->alertResized();
 }
 
 void MagicPlotComponent::changeListenerCallback (juce::ChangeBroadcaster*)


### PR DESCRIPTION
adds a needsResizing flag to the magicplotsource which is set whenever a magicplotcomponent is resized. can be used to redraw any plots.

this situation was handled in the filter plot by holding a rectangle and comparing it to the one passed into drawPlot. seeing as the analyzer also needs redrawing (eg when audio is paused and the spectrum is frozen), i thought this might generalize the necessity.

for the oscilloscope this is useless, of course. but for any plots which can ever possibly be static, it seemed like it could be useful.