### PR TITLE
Add rotary-horizontal-vertical option for sliders

### DIFF
--- a/General/foleys_MagicJUCEFactories.cpp
+++ b/General/foleys_MagicJUCEFactories.cpp
@@ -88,6 +88,8 @@ public:
         else if (type == pSliderTypes [3])
             slider.setSliderStyle (juce::Slider::Rotary);
         else if (type == pSliderTypes [4])
+            slider.setSliderStyle (juce::Slider::RotaryHorizontalVerticalDrag);
+        else if (type == pSliderTypes [5])
             slider.setSliderStyle (juce::Slider::IncDecButtons);
 
         auto textbox = getProperty (pSliderTextBox).toString();
@@ -142,7 +144,7 @@ private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (SliderItem)
 };
 const juce::Identifier  SliderItem::pSliderType   { "slider-type" };
-const juce::StringArray SliderItem::pSliderTypes  { "auto", "linear-horizontal", "linear-vertical", "rotary", "inc-dec-buttons" };
+const juce::StringArray SliderItem::pSliderTypes  { "auto", "linear-horizontal", "linear-vertical", "rotary", "rotary-horizontal-vertical", "inc-dec-buttons" };
 const juce::Identifier  SliderItem::pSliderTextBox    { "slider-textbox" };
 const juce::StringArray SliderItem::pTextBoxPositions { "no-textbox", "textbox-above", "textbox-below", "textbox-left", "textbox-right" };
 const juce::Identifier  SliderItem::pValue      { "value" };


### PR DESCRIPTION
As of [this commit](https://github.com/ffAudio/foleys_gui_magic/commit/e3ec4770600ddbf1d35664d90a39dd4ba4b19d5d#diff-1f69979a51cb22a165afdb9e2a5767c0R94), the "rotary" style for sliders refers to the `Slider::SliderStyle::Rotary` style. Since I use `SliderStyle::RotaryHorizontalVerticalDrag` quite often, I made that an option as well. I'd be happy to include more options (e.g. `SliderStyle::RotaryVerticalDrag`, `SliderStyle::LinearBar`) if you think that would be useful.