### PR TITLE
Release 1.3.1

### DIFF
--- a/Editor/foleys_PropertiesEditor.cpp
+++ b/Editor/foleys_PropertiesEditor.cpp
@@ -127,6 +127,8 @@ void PropertiesEditor::setNodeToEdit (juce::ValueTree node)
 
     addDecoratorProperties();
 
+    addFlexItemProperties();
+
     juce::Array<juce::PropertyComponent*> additional;
 
     if (stylesheet.isClassNode (styleItem))
@@ -141,8 +143,6 @@ void PropertiesEditor::setNodeToEdit (juce::ValueTree node)
 
     if (styleItem.getType() == IDs::view || stylesheet.isClassNode (styleItem))
         addContainerProperties();
-
-    addFlexItemProperties();
 
     if (stylesheet.isClassNode (styleItem))
         nodeSelect.setText (TRANS ("Class: ") + styleItem.getType().toString(), juce::dontSendNotification);
@@ -289,6 +289,11 @@ void PropertiesEditor::addFlexItemProperties()
 {
     juce::Array<juce::PropertyComponent*> array;
 
+    array.add (new StyleTextPropertyComponent (builder, IDs::posX, styleItem));
+    array.add (new StyleTextPropertyComponent (builder, IDs::posY, styleItem));
+    array.add (new StyleTextPropertyComponent (builder, IDs::posWidth, styleItem));
+    array.add (new StyleTextPropertyComponent (builder, IDs::posHeight, styleItem));
+
     array.add (new StyleTextPropertyComponent (builder, IDs::width, styleItem));
     array.add (new StyleTextPropertyComponent (builder, IDs::height, styleItem));
     array.add (new StyleTextPropertyComponent (builder, IDs::minWidth, styleItem));
@@ -300,7 +305,7 @@ void PropertiesEditor::addFlexItemProperties()
     array.add (new StyleTextPropertyComponent (builder, IDs::flexOrder, styleItem));
     array.add (new StyleChoicePropertyComponent (builder, IDs::flexAlignSelf, styleItem, { IDs::flexStretch, IDs::flexStart, IDs::flexEnd, IDs::flexCenter, IDs::flexAuto }));
 
-    properties.addSection ("Flex-Item", array, false);
+    properties.addSection ("Item", array, false);
 }
 
 void PropertiesEditor::addContainerProperties()

--- a/General/foleys_MagicGUIBuilder.cpp
+++ b/General/foleys_MagicGUIBuilder.cpp
@@ -218,6 +218,14 @@ GuiItem* MagicGUIBuilder::findGuiItemWithId (const juce::String& name)
     return nullptr;
 }
 
+GuiItem* MagicGUIBuilder::findGuiItem (const juce::ValueTree& node)
+{
+    if (node.isValid() && root)
+        return root->findGuiItem (node);
+
+    return nullptr;
+}
+
 void MagicGUIBuilder::registerFactory (juce::Identifier type, std::unique_ptr<GuiItem>(*factory)(MagicGUIBuilder& builder, const juce::ValueTree&))
 {
     if (factories.find (type) != factories.cend())
@@ -389,9 +397,15 @@ void MagicGUIBuilder::setSelectedNode (const juce::ValueTree& node)
 {
     if (selectedNode != node)
     {
+        if (auto* item = findGuiItem (selectedNode))
+            item->setDraggable (false);
+
         selectedNode = node;
         if (magicToolBox.get() != nullptr)
             magicToolBox->setSelectedNode (selectedNode);
+
+        if (auto* item = findGuiItem (selectedNode))
+            item->setDraggable (true);
 
         if (parent != nullptr)
             parent->repaint();

--- a/General/foleys_MagicGUIBuilder.h
+++ b/General/foleys_MagicGUIBuilder.h
@@ -82,6 +82,11 @@ public:
     GuiItem* findGuiItemWithId (const juce::String& name);
 
     /**
+     Seeks recursively for a GuiItem
+     */
+    GuiItem* findGuiItem (const juce::ValueTree& node);
+
+    /**
      This selects the stylesheet node and sets it to the Stylesheet.
      If no stylesheet is found, a default one is created.
      */

--- a/General/foleys_MagicPluginEditor.cpp
+++ b/General/foleys_MagicPluginEditor.cpp
@@ -71,6 +71,7 @@ void MagicPluginEditor::initialise (const char* data, int dataSize)
     if (builder.get() == nullptr)
         builder = createBuilderInstance();
 
+#if FOLEYS_SAVE_EDITED_GUI_IN_PLUGIN_STATE
     auto guiTree = processorState.getValueTree().getChildWithName ("magic");
     if (guiTree.isValid())
         setConfigTree (guiTree);
@@ -78,6 +79,9 @@ void MagicPluginEditor::initialise (const char* data, int dataSize)
         setConfigTree (data, dataSize);
     else
         builder->createGUI (*this);
+#else  // FOLEYS_SAVE_EDITED_GUI_IN_PLUGIN_STATE
+    auto guiTree = processorState.getGuiTree();
+#endif // FOLEYS_SAVE_EDITED_GUI_IN_PLUGIN_STATE
 
     updateSize();
 

--- a/General/foleys_MagicPluginEditor.h
+++ b/General/foleys_MagicPluginEditor.h
@@ -48,8 +48,12 @@ class MagicPluginEditor  : public juce::AudioProcessorEditor,
                            public juce::DragAndDropContainer
 {
 public:
+    /**
+     Create an AudioProcessorEditor populated from a MagicGUIBuilder.
+     */
     MagicPluginEditor (MagicProcessorState& processorState, std::unique_ptr<MagicGUIBuilder> builder = {});
 
+    [[deprecated ("MagicPluginEditor will get the state from the processorState. Call processorState.setGuiValueTree() beforehand.")]]
     MagicPluginEditor (MagicProcessorState& processorState, const char* data, const int dataSize, std::unique_ptr<MagicGUIBuilder> builder = {});
 
     ~MagicPluginEditor() override;

--- a/General/foleys_MagicProcessor.h
+++ b/General/foleys_MagicProcessor.h
@@ -62,7 +62,12 @@ public:
     MagicProcessor (const std::initializer_list<const short[2]>& channelLayoutList);
 
     /**
-     Override that method to initialise the builder, register your own bespoke components or LookAndFeel classes
+     Override that method to initialise the builder, register your own bespoke components or LookAndFeel classes.
+     If you override this and you want to use the bundled components don't forget to call
+     \code{.cpp}
+     builder.registerJUCEFactories();
+     builder.registerJUCELookAndFeels();
+     \endcode
      */
     virtual void initialiseBuilder (MagicGUIBuilder& builder);
 

--- a/General/foleys_MagicProcessor.h
+++ b/General/foleys_MagicProcessor.h
@@ -43,6 +43,16 @@ namespace foleys
  This is a convenience class to create a plugin using PluginGuiMagic. It has all wired up for you,
  The MagicPluginEditor for you to design or use the generic default, the loading and saving of the state
  and many more.
+
+ In the constructor you can create the GUI ValueTree either by using
+ \code{.cpp}
+ // generate a default GUI deduced from Parameters, ParameterGroups and MagicPlotSources
+ auto defaultGUI = magicState.createDefaultGUITree();
+ magicState.setGuiValueTree (defaultGUI);
+
+ // or you load an existing one from BinaryData
+ magicState.setGuiValueTree (BinaryData::magic_xml, BinaryData::magic_xmlSize);
+ \endcode
  */
 class MagicProcessor  : public juce::AudioProcessor
 {

--- a/General/foleys_StringDefinitions.h
+++ b/General/foleys_StringDefinitions.h
@@ -158,6 +158,11 @@ namespace IDs
     static juce::Identifier width       { "width" };
     static juce::Identifier height      { "height" };
 
+    static juce::Identifier posX        { "pos-x" };
+    static juce::Identifier posY        { "pos-y" };
+    static juce::Identifier posWidth    { "pos-width" };
+    static juce::Identifier posHeight   { "pos-height" };
+
     static juce::Identifier properties  { "Properties" };
     static juce::Identifier lastSize    { "last-size" };
 }

--- a/Layout/foleys_Container.cpp
+++ b/Layout/foleys_Container.cpp
@@ -51,11 +51,11 @@ void Container::update()
 
     const auto display = magicBuilder.getStyleProperty (IDs::display, configNode).toString();
     if (display == IDs::contents)
-        setLayoutMode (Container::Layout::Contents);
+        setLayoutMode (LayoutType::Contents);
     else if (display == IDs::tabbed)
-        setLayoutMode (Container::Layout::Tabbed);
+        setLayoutMode (LayoutType::Tabbed);
     else
-        setLayoutMode (Container::Layout::FlexBox);
+        setLayoutMode (LayoutType::FlexBox);
 
     auto repaintHz = magicBuilder.getStyleProperty (IDs::repaintHz, configNode).toString();
     if (repaintHz.isNotEmpty())
@@ -115,10 +115,10 @@ GuiItem* Container::findGuiItem (const juce::ValueTree& node)
     return nullptr;
 }
 
-void Container::setLayoutMode (Layout layoutToUse)
+void Container::setLayoutMode (LayoutType layoutToUse)
 {
     layout = layoutToUse;
-    if (layout == Layout::Tabbed)
+    if (layout == LayoutType::Tabbed)
     {
         updateTabbedButtons();
     }
@@ -132,7 +132,7 @@ void Container::setLayoutMode (Layout layoutToUse)
     updateLayout();
 }
 
-Container::Layout Container::getLayoutMode() const
+LayoutType Container::getLayoutMode() const
 {
     return layout;
 }
@@ -149,10 +149,10 @@ void Container::updateLayout()
 
     auto clientBounds = getClientBounds();
 
-    if (layout != Layout::Tabbed)
+    if (layout != LayoutType::Tabbed)
         tabbedButtons.reset();
 
-    if (layout == Layout::FlexBox)
+    if (layout == LayoutType::FlexBox)
     {
         flexBox.items.clear();
         for (auto& child : children)
@@ -160,7 +160,7 @@ void Container::updateLayout()
 
         flexBox.performLayout (clientBounds);
     }
-    else if (layout == Layout::Tabbed)
+    else if (layout == LayoutType::Tabbed)
     {
         updateTabbedButtons();
         tabbedButtons->setBounds (clientBounds.removeFromTop (30));

--- a/Layout/foleys_Container.cpp
+++ b/Layout/foleys_Container.cpp
@@ -120,6 +120,11 @@ void Container::setLayoutMode (Layout layoutToUse)
     updateLayout();
 }
 
+Container::Layout Container::getLayoutMode() const
+{
+    return layout;
+}
+
 void Container::resized()
 {
     updateLayout();
@@ -132,6 +137,9 @@ void Container::updateLayout()
 
     auto clientBounds = getClientBounds();
 
+    if (layout != Layout::Tabbed)
+        tabbedButtons.reset();
+
     if (layout == Layout::FlexBox)
     {
         flexBox.items.clear();
@@ -140,18 +148,18 @@ void Container::updateLayout()
 
         flexBox.performLayout (clientBounds);
     }
-    else
+    else if (layout == Layout::Tabbed)
     {
-        if (layout == Layout::Tabbed)
-        {
-            updateTabbedButtons();
-            tabbedButtons->setBounds (clientBounds.removeFromTop (30));
-        }
-        else
-            tabbedButtons.reset();
+        updateTabbedButtons();
+        tabbedButtons->setBounds (clientBounds.removeFromTop (30));
 
         for (auto& child : children)
             child->setBounds (clientBounds);
+    }
+    else // layout == Layout::Contents
+    {
+        for (auto& child : children)
+            child->setBounds (child->resolvePosition (clientBounds));
     }
 
     for (auto& child : children)

--- a/Layout/foleys_Container.cpp
+++ b/Layout/foleys_Container.cpp
@@ -103,6 +103,18 @@ GuiItem* Container::findGuiItemWithId (const juce::String& name)
     return nullptr;
 }
 
+GuiItem* Container::findGuiItem (const juce::ValueTree& node)
+{
+    if (node == configNode)
+        return this;
+
+    for (auto& child : children)
+        if (auto* item = child->findGuiItem (node))
+            return item;
+
+    return nullptr;
+}
+
 void Container::setLayoutMode (Layout layoutToUse)
 {
     layout = layoutToUse;

--- a/Layout/foleys_Container.h
+++ b/Layout/foleys_Container.h
@@ -108,6 +108,11 @@ public:
      */
     GuiItem* findGuiItemWithId (const juce::String& name) override;
 
+    /**
+     Seeks recursively for a GuiItem
+     */
+    GuiItem* findGuiItem (const juce::ValueTree& node) override;
+
 #if FOLEYS_SHOW_GUI_EDITOR_PALLETTE
     /**
      This switches this node and all it's descendents in the edit

--- a/Layout/foleys_Container.h
+++ b/Layout/foleys_Container.h
@@ -42,6 +42,16 @@ namespace foleys
 class MagicPlotComponent;
 
 /**
+ The LayoutType defines after which method
+ */
+enum class LayoutType
+{
+    Contents,
+    FlexBox,
+    Tabbed
+};
+
+/**
  The Container is a GuiItem, that can hold multiple Components.
  In the editor it is seen as "View". With the setting "display"
  the layout strategy can be chosen.
@@ -51,13 +61,6 @@ class Container   : public GuiItem,
                     private juce::Timer
 {
 public:
-    enum class Layout
-    {
-        Contents,
-        FlexBox,
-        Tabbed
-    };
-
     Container (MagicGUIBuilder& builder, juce::ValueTree node);
 
     /**
@@ -76,12 +79,12 @@ public:
     /**
      Sets the layout mode of the container
      */
-    void setLayoutMode (Layout layout);
+    void setLayoutMode (LayoutType layout);
 
     /**
      Returns the current layout mode
      */
-    Layout getLayoutMode() const;
+    LayoutType getLayoutMode() const;
 
     void resized() override;
 
@@ -133,7 +136,7 @@ private:
     int  currentTab = 0;
     int  refreshRateHz = 30;
 
-    Layout layout = Layout::FlexBox;
+    LayoutType layout = LayoutType::FlexBox;
     juce::FlexBox flexBox;
 
     std::unique_ptr<juce::TabbedButtonBar>  tabbedButtons;

--- a/Layout/foleys_Container.h
+++ b/Layout/foleys_Container.h
@@ -78,6 +78,11 @@ public:
      */
     void setLayoutMode (Layout layout);
 
+    /**
+     Returns the current layout mode
+     */
+    Layout getLayoutMode() const;
+
     void resized() override;
 
     bool isContainer() const override { return true; }

--- a/Layout/foleys_GuiItem.cpp
+++ b/Layout/foleys_GuiItem.cpp
@@ -91,6 +91,7 @@ void GuiItem::updateInternal()
     decorator.configure (magicBuilder, configNode);
     configureComponent();
     configureFlexBoxItem (configNode);
+    configurePosition (configNode);
 
     updateColours();
 
@@ -186,6 +187,40 @@ void GuiItem::configureFlexBoxItem (const juce::ValueTree& node)
         flexItem.alignSelf = juce::FlexItem::AlignSelf::autoAlign;
     else
         flexItem.alignSelf = juce::FlexItem::AlignSelf::stretch;
+}
+
+void GuiItem::configurePosition (const juce::ValueTree& node)
+{
+    configurePosition (magicBuilder.getStyleProperty (IDs::posX, node), posX, 0.0);
+    configurePosition (magicBuilder.getStyleProperty (IDs::posY, node), posY, 0.0);
+    configurePosition (magicBuilder.getStyleProperty (IDs::posWidth, node), posWidth, 100.0);
+    configurePosition (magicBuilder.getStyleProperty (IDs::posHeight, node), posHeight, 100.0);
+}
+
+void GuiItem::configurePosition (const juce::var& v, Position& p, double d)
+{
+    if (v.isVoid())
+    {
+        p.absolute = false;
+        p.value = d;
+    }
+    else
+    {
+        auto const s = v.toString();
+        p.absolute = ! s.endsWith ("%");
+        p.value = s.getDoubleValue();
+    }
+}
+
+juce::Rectangle<int> GuiItem::resolvePosition (juce::Rectangle<int> parent)
+{
+    return juce::Rectangle<int>
+    (
+        parent.getX() + juce::roundToInt (posX.absolute ? posX.value : posX.value * parent.getWidth() * 0.01),
+        parent.getY() + juce::roundToInt (posY.absolute ? posY.value : posY.value * parent.getHeight() * 0.01),
+        juce::roundToInt (posWidth.absolute ? posWidth.value : posWidth.value * parent.getWidth() * 0.01),
+        juce::roundToInt (posHeight.absolute ? posHeight.value : posHeight.value * parent.getHeight() * 0.01)
+    );
 }
 
 void GuiItem::paint (juce::Graphics& g)

--- a/Layout/foleys_GuiItem.h
+++ b/Layout/foleys_GuiItem.h
@@ -125,7 +125,17 @@ public:
      */
     virtual void updateLayout();
 
+    /**
+     Parse the values and set it to the FlexBox::Item for layouting.
+     */
     void configureFlexBoxItem (const juce::ValueTree& node);
+
+    void configurePosition (const juce::ValueTree& node);
+
+    /**
+     Calculates the position according to the parent area
+     */
+    juce::Rectangle<int> resolvePosition (juce::Rectangle<int> parent);
 
     /**
      Returns the bounds of the wrapped Component. This is the GuiItems bounds
@@ -193,6 +203,15 @@ private:
     juce::Value     visibility { true };
 
     juce::String    highlight;
+
+    struct Position
+    {
+        bool   absolute = true;
+        double value = 0.0;
+    };
+    Position posX, posY, posWidth, posHeight;
+
+    void configurePosition (const juce::var& v, Position& p, double d);
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (GuiItem)
 };

--- a/Layout/foleys_GuiItem.h
+++ b/Layout/foleys_GuiItem.h
@@ -42,6 +42,8 @@ namespace foleys
 class MagicGUIBuilder;
 class MagicGUIState;
 
+enum class LayoutType;
+
 /**
  The GuiItem class will draw borders and descriptions around widgets, if defined.
  It also owns the Component and the Attachment, in case the Component is connected
@@ -124,6 +126,11 @@ public:
      This will trigger a recalculation of the children layout regardless of resized
      */
     virtual void updateLayout();
+
+    /**
+     Returns the layout type this item is managed by.
+     */
+    LayoutType getParentsLayoutType() const;
 
     /**
      Parse the values and set it to the FlexBox::Item for layouting.
@@ -217,6 +224,7 @@ private:
         JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (BorderDragger)
     };
     std::unique_ptr<BorderDragger> borderDragger;
+    juce::ComponentDragger         componentDragger;
 
     void valueChanged (juce::Value& source) override;
 

--- a/State/foleys_MagicGUIState.cpp
+++ b/State/foleys_MagicGUIState.cpp
@@ -93,6 +93,13 @@ void MagicGUIState::setGuiValueTree (const char* data, int dataSize)
         setGuiValueTree (dom);
 }
 
+void MagicGUIState::setGuiValueTree (const juce::File& file)
+{
+    auto dom = juce::ValueTree::fromXml (file.loadFileAsString());
+    if (dom.isValid())
+        guiValueTree = dom;
+}
+
 juce::ValueTree& MagicGUIState::getGuiTree()
 {
     return guiValueTree;

--- a/State/foleys_MagicGUIState.h
+++ b/State/foleys_MagicGUIState.h
@@ -78,6 +78,7 @@ public:
      */
     void setGuiValueTree (const juce::ValueTree& dom);
     void setGuiValueTree (const char* data, int dataSize);
+    void setGuiValueTree (const juce::File& file);
 
     /**
      Grants access to the gui tree. This is returned as reference so you are able to connect listeners to it.

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,6 +1,11 @@
 PluginGuiMagic - Versions history
 ================================
 
+1.3.1
+-----
+
+- Added options to specify position and size relative or absolute to the parent component
+
 1.3.0 - 28.02.2021
 ------------------
 

--- a/VERSION.md
+++ b/VERSION.md
@@ -6,6 +6,8 @@ PluginGuiMagic - Versions history
 
 - Added options to specify position and size relative or absolute to the parent component
 - Allow the selected component in a Contents to be draggable
+- Add a switch to disable storing the tree in the plugin state
+- Allow loading the gui from an external XML file without compilation
 
 1.3.0 - 28.02.2021
 ------------------

--- a/VERSION.md
+++ b/VERSION.md
@@ -5,6 +5,7 @@ PluginGuiMagic - Versions history
 -----
 
 - Added options to specify position and size relative or absolute to the parent component
+- Allow the selected component in a Contents to be draggable
 
 1.3.0 - 28.02.2021
 ------------------

--- a/Widgets/foleys_MagicPlotComponent.h
+++ b/Widgets/foleys_MagicPlotComponent.h
@@ -40,6 +40,7 @@ namespace foleys
 {
 
 /**
+ The MagicPlotComponent allows drawing the data from a MagicPlotSource.
  */
 class MagicPlotComponent  : public juce::Component
 {

--- a/Widgets/foleys_XYDragComponent.h
+++ b/Widgets/foleys_XYDragComponent.h
@@ -40,6 +40,7 @@ namespace foleys
 {
 
 /**
+ This is a 2D parameter dragging component.
  */
 class XYDragComponent  : public juce::Component
 {

--- a/foleys_gui_magic.h
+++ b/foleys_gui_magic.h
@@ -61,6 +61,14 @@
 #define FOLEYS_SHOW_GUI_EDITOR_PALLETTE 1
 #endif
 
+/** Config: FOLEYS_SAVE_EDITED_GUI_IN_PLUGIN_STATE
+            This will save the currently edited GUI in the plugin instances state. Best to turn this off
+            in the product to avoid confusion in updates.
+  */
+#ifndef FOLEYS_SAVE_EDITED_GUI_IN_PLUGIN_STATE
+#define FOLEYS_SAVE_EDITED_GUI_IN_PLUGIN_STATE 1
+#endif
+
 /** Config: FOLEYS_ENABLE_BINARY_DATA
             Makes the binary resources available to the GUI. Make sure you actually have
             at least one file added, or this will fail to compile.

--- a/foleys_gui_magic.h
+++ b/foleys_gui_magic.h
@@ -37,7 +37,7 @@
 
     ID:            foleys_gui_magic
     vendor:        Foleys Finest Audio
-    version:       1.3.0
+    version:       1.3.1
     name:          Foleys GUI magic
     description:   This module allows to create GUI with a drag and drop editor
     dependencies:  juce_core, juce_audio_basics, juce_audio_devices, juce_audio_formats,


### PR DESCRIPTION
- Added options to specify position and size relative or absolute to the parent component
- Allow the selected component in a Contents to be draggable
- Add a switch to disable storing the tree in the plugin state
- Allow loading the gui from an external XML file without compilation
