### PR TITLE
Opaque containers

### DIFF
--- a/Editor/foleys_StylePropertyComponent.cpp
+++ b/Editor/foleys_StylePropertyComponent.cpp
@@ -76,6 +76,13 @@ StylePropertyComponent::StylePropertyComponent (MagicGUIBuilder& builderToUse, j
         node.removeProperty (property, &builder.getUndoManager());
         refresh();
     };
+
+    node.addListener (this);
+}
+
+StylePropertyComponent::~StylePropertyComponent()
+{
+    node.removeListener (this);
 }
 
 juce::var StylePropertyComponent::lookupValue()
@@ -131,5 +138,10 @@ void StylePropertyComponent::mouseDoubleClick (const juce::MouseEvent&)
         builder.getMagicToolBox().setNodeToEdit (inheritedFrom);
 }
 
+void StylePropertyComponent::valueTreePropertyChanged (juce::ValueTree& tree, const juce::Identifier& changedProperty)
+{
+    if (tree == node && property == changedProperty)
+        refresh();
+}
 
 } // namespace foleys

--- a/Editor/foleys_StylePropertyComponent.h
+++ b/Editor/foleys_StylePropertyComponent.h
@@ -40,10 +40,12 @@ namespace foleys
 {
 
 
-class StylePropertyComponent  : public juce::PropertyComponent
+class StylePropertyComponent  : public juce::PropertyComponent,
+                                private juce::ValueTree::Listener
 {
 public:
     StylePropertyComponent (MagicGUIBuilder& builder, juce::Identifier property, juce::ValueTree& node);
+    ~StylePropertyComponent() override;
 
     void paint (juce::Graphics& g) override;
     void resized() override;
@@ -65,6 +67,8 @@ protected:
     juce::TextButton    remove { "X" };
 
 private:
+    void valueTreePropertyChanged (juce::ValueTree& treeWhosePropertyHasChanged,
+                                   const juce::Identifier& changedProperty) override;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (StylePropertyComponent)
 };

--- a/Layout/foleys_Container.cpp
+++ b/Layout/foleys_Container.cpp
@@ -322,9 +322,12 @@ void Container::setEditMode (bool shouldEdit)
 
 //==============================================================================
 
+Container::ContainerBox::ContainerBox (Container& ownerToUse)
+: owner (ownerToUse) {}
+
 void Container::ContainerBox::paint (juce::Graphics& g)
 {
-    g.fillAll (backgroundColour);
+    owner.decorator.drawDecorator (g, {-getX(), -getY(), owner.getWidth(), owner.getHeight()});
 }
 
 void Container::ContainerBox::setBackgroundColour (juce::Colour colour)

--- a/Layout/foleys_Container.h
+++ b/Layout/foleys_Container.h
@@ -129,11 +129,13 @@ private:
     class ContainerBox : public juce::Component
     {
     public:
-        ContainerBox() = default;
+        ContainerBox (Container& owner);
+
         void paint (juce::Graphics& g) override;
         void setBackgroundColour (juce::Colour colour);
 
     private:
+        Container& owner;
         juce::Colour backgroundColour;
         JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ContainerBox)
     };
@@ -150,7 +152,7 @@ private:
     LayoutType layout = LayoutType::FlexBox;
     juce::FlexBox flexBox;
 
-    ContainerBox containerBox;
+    ContainerBox containerBox { *this };
     std::unique_ptr<juce::TabbedButtonBar>  tabbedButtons;
     std::vector<std::unique_ptr<GuiItem>> children;
 

--- a/Layout/foleys_Container.h
+++ b/Layout/foleys_Container.h
@@ -126,6 +126,17 @@ public:
 #endif
 
 private:
+    class ContainerBox : public juce::Component
+    {
+    public:
+        ContainerBox() = default;
+        void paint (juce::Graphics& g) override;
+        void setBackgroundColour (juce::Colour colour);
+
+    private:
+        juce::Colour backgroundColour;
+        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ContainerBox)
+    };
 
     void changeListenerCallback (juce::ChangeBroadcaster*) override;
     void timerCallback() override;
@@ -139,6 +150,7 @@ private:
     LayoutType layout = LayoutType::FlexBox;
     juce::FlexBox flexBox;
 
+    ContainerBox containerBox;
     std::unique_ptr<juce::TabbedButtonBar>  tabbedButtons;
     std::vector<std::unique_ptr<GuiItem>> children;
 

--- a/Layout/foleys_Decorator.cpp
+++ b/Layout/foleys_Decorator.cpp
@@ -104,6 +104,11 @@ juce::Colour Decorator::getTabColour() const
     return tabColour;
 }
 
+juce::Colour Decorator::getBackgroundColour() const
+{
+    return backgroundColour;
+}
+
 void Decorator::updateColours (MagicGUIBuilder& builder, const juce::ValueTree& node)
 {
     auto& stylesheet = builder.getStylesheet();

--- a/Layout/foleys_Decorator.h
+++ b/Layout/foleys_Decorator.h
@@ -68,6 +68,8 @@ public:
     juce::String getTabCaption (const juce::String& defaultName) const;
     juce::Colour getTabColour() const;
 
+    juce::Colour getBackgroundColour() const;
+
 private:
 
     juce::Colour backgroundColour { juce::Colours::darkgrey };

--- a/Layout/foleys_GuiItem.cpp
+++ b/Layout/foleys_GuiItem.cpp
@@ -428,7 +428,7 @@ void GuiItem::setDraggable (bool selected)
 
 void GuiItem::savePosition ()
 {
-    auto* container = dynamic_cast<Container*>(getParentComponent());
+    auto* container = findParentComponentOfClass<Container>();
 
     if (container == nullptr)
         return;

--- a/Layout/foleys_GuiItem.cpp
+++ b/Layout/foleys_GuiItem.cpp
@@ -291,7 +291,7 @@ void GuiItem::valueTreePropertyChanged (juce::ValueTree& treeThatChanged, const 
 {
     if (treeThatChanged == configNode)
     {
-        if (auto* parent = dynamic_cast<GuiItem*>(getParentComponent()))
+        if (auto* parent = findParentComponentOfClass<GuiItem>())
             parent->updateInternal();
         else
             updateInternal();


### PR DESCRIPTION
This change will draw containers backgrounds as opaque if an opaque colour is set. This should avoid repainting parents.