### PR TITLE
Midi display

### DIFF
--- a/modules/foleys_gui_magic/General/foleys_MagicJUCEFactories.cpp
+++ b/modules/foleys_gui_magic/General/foleys_MagicJUCEFactories.cpp
@@ -40,6 +40,7 @@
 #include "../Widgets/foleys_MagicLevelMeter.h"
 #include "../Widgets/foleys_MagicPlotComponent.h"
 #include "../Widgets/foleys_MidiLearnComponent.h"
+#include "../Widgets/foleys_MidiDisplayComponent.h"
 #include "../Widgets/foleys_MidiDrumpadComponent.h"
 #include "../Helpers/foleys_PopupMenuHelper.h"
 
@@ -891,6 +892,34 @@ private:
 
 //==============================================================================
 
+class MidiDisplayItem : public GuiItem
+{
+public:
+    FOLEYS_DECLARE_GUI_FACTORY (MidiDisplayItem)
+
+    MidiDisplayItem (MagicGUIBuilder& builder, const juce::ValueTree& node) : GuiItem (builder, node)
+    {
+        if (auto* state = dynamic_cast<MagicProcessorState*>(&builder.getMagicState()))
+            midiDisplay.setMagicProcessorState (state);
+
+        addAndMakeVisible (midiDisplay);
+    }
+
+    void update() override {}
+
+    juce::Component* getWrappedComponent() override
+    {
+        return &midiDisplay;
+    }
+
+private:
+    MidiDisplayComponent midiDisplay;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (MidiDisplayItem)
+};
+
+//==============================================================================
+
 class ListBoxItem : public GuiItem,
                     public juce::ChangeListener
 {
@@ -995,6 +1024,7 @@ void MagicGUIBuilder::registerJUCEFactories()
     registerFactory (IDs::drumpadComponent, &DrumpadItem::factory);
     registerFactory (IDs::meter, &LevelMeterItem::factory);
     registerFactory ("MidiLearn", &MidiLearnItem::factory);
+    registerFactory ("MidiDisplay", &MidiDisplayItem::factory);
     registerFactory (IDs::listBox, &ListBoxItem::factory);
 
 #if JUCE_MODULE_AVAILABLE_juce_gui_extra && JUCE_WEB_BROWSER

--- a/modules/foleys_gui_magic/State/foleys_MagicProcessorState.cpp
+++ b/modules/foleys_gui_magic/State/foleys_MagicProcessorState.cpp
@@ -226,6 +226,16 @@ int MagicProcessorState::getLastController() const
     return midiMapper.getLastController();
 }
 
+int MagicProcessorState::getLastMidiChannel() const
+{
+    return midiMapper.getLastMidiChannel();
+}
+
+int MagicProcessorState::getLastMidiNote() const
+{
+    return midiMapper.getLastMidiNote();
+}
+
 void MagicProcessorState::timerCallback()
 {
     getPropertyAsValue ("playhead:bpm").setValue (bpm.load());

--- a/modules/foleys_gui_magic/State/foleys_MagicProcessorState.cpp
+++ b/modules/foleys_gui_magic/State/foleys_MagicProcessorState.cpp
@@ -236,6 +236,11 @@ int MagicProcessorState::getLastMidiNote() const
     return midiMapper.getLastMidiNote();
 }
 
+int MagicProcessorState::getLastMidiVelocity() const
+{
+    return midiMapper.getLastMidiVelocity();
+}
+
 void MagicProcessorState::timerCallback()
 {
     getPropertyAsValue ("playhead:bpm").setValue (bpm.load());

--- a/modules/foleys_gui_magic/State/foleys_MagicProcessorState.h
+++ b/modules/foleys_gui_magic/State/foleys_MagicProcessorState.h
@@ -131,6 +131,21 @@ public:
      */
     int  getLastController() const;
 
+    /**
+     Returns the last MIDI Channel on which MIDI was received by MIDI Mapper
+     */
+     int getLastMidiChannel() const;
+
+    /**
+     Returns the last MIDI Note received by MIDI Mapper
+     */
+     int getLastMidiNote() const;
+
+    /**
+     Returns the last MIDI Velocity received by MIDI Mapper
+     */
+     int getLastMidiVelocity() const;
+
 private:
 
     void addParametersToMenu (const juce::AudioProcessorParameterGroup& group, juce::PopupMenu& menu, int& index) const;

--- a/modules/foleys_gui_magic/State/foleys_MidiParameterMapper.cpp
+++ b/modules/foleys_gui_magic/State/foleys_MidiParameterMapper.cpp
@@ -59,10 +59,11 @@ void MidiParameterMapper::processMidiBuffer (juce::MidiBuffer& buffer)
 
     for (auto m : buffer)
     {
-        if (m.getMessage().isController())
+        juce::MidiMessage mm = m.getMessage();
+        if (mm.isController())
         {
-            auto number = m.getMessage().getControllerNumber();
-            auto value  = m.getMessage().getControllerValue() / 127.0f;
+            auto number = mm.getControllerNumber();
+            auto value  = mm.getControllerValue() / 127.0f;
             lastController.store (number);
 
             if (isLocked)
@@ -78,6 +79,11 @@ void MidiParameterMapper::processMidiBuffer (juce::MidiBuffer& buffer)
                     p->endChangeGesture();
                 }
             }
+        } else if (mm.isNoteOn())
+        {
+            lastMidiChannel.store(mm.getChannel());
+            lastMidiNote.store(mm.getNoteNumber());
+            lastMidiVelocity.store(mm.getVelocity());
         }
     }
 
@@ -90,6 +96,20 @@ void MidiParameterMapper::mapMidiController (int cc, const juce::String& paramet
     auto mappings = getMappingSettings();
 
     juce::ValueTree node { IDs::mapping, {{IDs::cc, cc}, {IDs::parameter, parameterID}} };
+
+    // If mapping already there, remove it:
+    if (mappings.isValid()) {
+      int index = 0;
+      while (index < mappings.getNumChildren()) {
+        const auto& child = mappings.getChild (index);
+        if (int (child.getProperty (IDs::cc, -1)) == cc && child.getProperty (IDs::parameter, juce::String()).toString() == parameterID) {
+          mappings.removeChild (child, nullptr);
+          return;
+        } else
+          ++index;
+      }
+    }
+    // Otherwise add it:
     mappings.appendChild (node, nullptr);
 }
 

--- a/modules/foleys_gui_magic/State/foleys_MidiParameterMapper.cpp
+++ b/modules/foleys_gui_magic/State/foleys_MidiParameterMapper.cpp
@@ -132,6 +132,21 @@ int MidiParameterMapper::getLastController() const
     return lastController.load();
 }
 
+int MidiParameterMapper::getLastMidiChannel() const
+{
+    return lastMidiChannel.load();
+}
+
+int MidiParameterMapper::getLastMidiNote() const
+{
+    return lastMidiNote.load();
+}
+
+int MidiParameterMapper::getLastMidiVelocity() const
+{
+    return lastMidiVelocity.load();
+}
+
 juce::ValueTree MidiParameterMapper::getMappingSettings()
 {
     return settings->settings.getOrCreateChildWithName (IDs::mappings, nullptr);

--- a/modules/foleys_gui_magic/State/foleys_MidiParameterMapper.h
+++ b/modules/foleys_gui_magic/State/foleys_MidiParameterMapper.h
@@ -113,6 +113,9 @@ private:
 
     MagicProcessorState&        state;
     std::atomic<int>            lastController { -1 };
+    std::atomic<int>            lastMidiChannel { -1 };
+    std::atomic<int>            lastMidiNote { -1 };
+    std::atomic<int>            lastMidiVelocity { -1 };
     MidiMapping                 midiMapper;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (MidiParameterMapper)

--- a/modules/foleys_gui_magic/State/foleys_MidiParameterMapper.h
+++ b/modules/foleys_gui_magic/State/foleys_MidiParameterMapper.h
@@ -77,6 +77,21 @@ public:
     int  getLastController() const;
 
     /*!
+     * @return the last MIDI Channel on which MIDI was received by MIDI Mapper
+     */
+    int  getLastMidiChannel() const;
+
+    /*!
+     * @return the last MIDI Note received by MIDI Mapper
+     */
+    int  getLastMidiNote() const;
+
+    /*!
+     * @return the last MIDI Velocity received by MIDI Mapper
+     */
+    int  getLastMidiVelocity() const;
+
+    /*!
      * Grant access to the ValueTree to save or restore the mappings manually
      * @return the ValueTree containing the mappings
      */

--- a/modules/foleys_gui_magic/foleys_gui_magic.cpp
+++ b/modules/foleys_gui_magic/foleys_gui_magic.cpp
@@ -72,6 +72,7 @@
 #include "Widgets/foleys_XYDragComponent.cpp"
 #include "Widgets/foleys_FileBrowserDialog.cpp"
 #include "Widgets/foleys_MidiLearnComponent.cpp"
+#include "Widgets/foleys_MidiDisplayComponent.cpp"
 #include "Widgets/foleys_MidiDrumpadComponent.cpp"
 
 #include "LookAndFeels/foleys_JuceLookAndFeels.cpp"

--- a/modules/foleys_gui_magic/foleys_gui_magic.h
+++ b/modules/foleys_gui_magic/foleys_gui_magic.h
@@ -129,6 +129,7 @@
 #include "Widgets/foleys_XYDragComponent.h"
 #include "Widgets/foleys_FileBrowserDialog.h"
 #include "Widgets/foleys_MidiLearnComponent.h"
+#include "Widgets/foleys_MidiDisplayComponent.h"
 #include "Widgets/foleys_MidiDrumpadComponent.h"
 
 #include "State/foleys_RadioButtonManager.h"


### PR DESCRIPTION
Adds a simple MidiDisplay GuiItem similar to MidiLearn, which displays the last MIDI NoteOn parameters as well as MIDI controller, like most DAWs:
![image](https://github.com/ffAudio/foleys_gui_magic/assets/2200853/39eb15bc-000e-4a3e-96c6-e2497cfe6990)
Also, if MidiLearn is repeated, it deletes the previous assignment, giving a simple delete mechanism for the mapping.