### PR TITLE
Fix bug where clicking a toggle button would not change its toggle state

### DIFF
--- a/modules/foleys_gui_magic/General/foleys_MagicJUCEFactories.cpp
+++ b/modules/foleys_gui_magic/General/foleys_MagicJUCEFactories.cpp
@@ -401,8 +401,6 @@ public:
             button.setRadioGroupId (groupID);
             button.setClickingTogglesState (true);
         }
-
-        handler.setRadioGroupValue(radioValue, getMagicState().getParameter(parameterName));
     }
 
     std::vector<SettableProperty> getSettableProperties() const override


### PR DESCRIPTION
Hello!

This is a fix for a bug where clicking on a toggle button attached to a parameter has no effect (i.e. the button and parameter values do not change). This can be reproduced in the EqualizerExample: clicking on the filter enable buttons have any effect (the filters do not disable, and the button state remains on).

The fix is to remove a call to setRadioGroupValue(), which seems unnecessary and problematic for toggle buttons.