### PR TITLE
Fixed type in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 **/.idea
 cmake-build-*
 [Bb]uilds/
-[Bb]build/
+[Bb]uild/
 logs/
 docs/
 **/*.sav.xml


### PR DESCRIPTION
The .gitignore file includes entries to exclude build folders, using expressions to select for either upper-case or lower-case folder titles, but included a typo that does not exclude folders named "Build" or "build" (see diff for the specifics, but in short, a redundant "b" was erroneously included).

This PR simply corrects this typo, so the default build folder generated with CMake on Linux (and possibly others, anything that uses "./build" or "./Build") is not tracked by mistake.

Thanks to everyone who contributed to this project!