### PR TITLE
Fix changes to decorator settings not updating the WYSIWYG view

### DIFF
--- a/modules/foleys_gui_magic/Layout/foleys_GuiItem.cpp
+++ b/modules/foleys_gui_magic/Layout/foleys_GuiItem.cpp
@@ -104,6 +104,9 @@ void GuiItem::updateInternal()
 
     setEditMode (magicBuilder.isEditModeOn());
 
+    // we need to call resized() because changes to decorators can cause *internal* layout changes
+    // and JUCE's setBounds() method thinks we don't need to do that because the outer bounds didn't change
+    resized();
     repaint();
 }
 


### PR DESCRIPTION
Apologies if this is not the right way to fix this! I was having an issue where changing a combo box's caption size was updating the font size live but NOT moving the rest of the combo box out of the way like it's supposed to. A save + reload would render everything correctly, so after some investigating, I think this is the fix.

I think it has to do with this kind of change only effects the layout inside this item, and the rest of the flexbox system only cares about changes outside the item. 

In any case, this does fix the problem. I did look pretty hard to see if I could put this more surgically somewhere relating to "the decorator has changed lets resize" but I think this might be the place? 

I'm happy to take a different approach, but hopefully the fact that this does appear to fix the issue will give some insight into what the problem is at least.

Steps to reproduce:
Make a combo box, give it a caption in its decorator, set the caption to center-left, change the caption's size and notice the font change but the internal bounds of the caption vs the combo box do not update.

Apply this patch and it will update.

Thanks!