### PR TITLE
Fix: Apply type defaults to nodes without class attribute

### DIFF
--- a/modules/foleys_gui_magic/Layout/foleys_Stylesheet.cpp
+++ b/modules/foleys_gui_magic/Layout/foleys_Stylesheet.cpp
@@ -222,6 +222,19 @@ juce::var Stylesheet::getStyleProperty (const juce::Identifier& name, const juce
         }
     }
 
+    // Check type defaults even if no class is assigned
+    if (inherit)
+    {
+        auto typeNode = currentStyle.getChildWithName (IDs::types).getChildWithName (node.getType());
+        if (typeNode.isValid() && typeNode.hasProperty (name))
+        {
+            if (definedHere)
+                *definedHere = typeNode;
+
+            return typeNode.getProperty (name);
+        }
+    }
+
     auto parent = node.getParent();
     if (parent.isValid() && parent.getType() != IDs::magic)
         return getStyleProperty (name, parent, false, definedHere);


### PR DESCRIPTION
The Types section in stylesheets was only being checked inside the class iteration loop, meaning nodes without any class attribute would never receive type defaults. This adds the type lookup as a fallback after the class loop.

For example, if you have:

```
<Types>
        <View background-color="$x" />
</Types>
```

The background color doesn't apply to Views with no class attached to them. If you add any class they do get picked up.