### PR TITLE
Add caption-gap property to Decorator

### DIFF
--- a/modules/foleys_gui_magic/Editor/foleys_PropertiesEditor.cpp
+++ b/modules/foleys_gui_magic/Editor/foleys_PropertiesEditor.cpp
@@ -276,6 +276,7 @@ void PropertiesEditor::addDecoratorProperties()
     array.add (new StyleChoicePropertyComponent (builder, IDs::visibility, styleItem, builder.createPropertiesMenuLambda()));
     array.add (new StyleTextPropertyComponent (builder, IDs::caption, styleItem));
     array.add (new StyleTextPropertyComponent (builder, IDs::captionSize, styleItem));
+    array.add (new StyleTextPropertyComponent (builder, IDs::captionGap, styleItem));
     array.add (new StyleColourPropertyComponent (builder, IDs::captionColour, styleItem));
     array.add (new StyleChoicePropertyComponent (builder, IDs::captionPlacement, styleItem, getAllKeyNames (makeJustificationsChoices())));
     array.add (new StyleTextPropertyComponent (builder, IDs::tooltip, styleItem));

--- a/modules/foleys_gui_magic/General/foleys_StringDefinitions.h
+++ b/modules/foleys_gui_magic/General/foleys_StringDefinitions.h
@@ -63,6 +63,7 @@ namespace IDs
     static juce::Identifier captionPlacement { "caption-placement" };
     static juce::Identifier captionColour { "caption-color" };
     static juce::Identifier captionSize  { "caption-size" };
+    static juce::Identifier captionGap   { "caption-gap" };
     static juce::Identifier lookAndFeel  { "lookAndFeel" };
     static juce::Identifier tooltip      { "tooltip" };
     static juce::Identifier tooltipText       { "tooltip-text" };

--- a/modules/foleys_gui_magic/Layout/foleys_Decorator.cpp
+++ b/modules/foleys_gui_magic/Layout/foleys_Decorator.cpp
@@ -134,18 +134,30 @@ Decorator::ClientBounds Decorator::getClientBounds (juce::Rectangle<int> overall
         if (justification == juce::Justification::centred)
             captionBox = overallBounds;
         else if (justification.getOnlyVerticalFlags() & juce::Justification::top)
+        {
             captionBox = box.removeFromTop (captionSize).toNearestInt();
+            box.removeFromTop (captionGap);
+        }
         else if (justification.getOnlyVerticalFlags() & juce::Justification::bottom)
+        {
             captionBox = box.removeFromBottom (captionSize).toNearestInt();
+            box.removeFromBottom (captionGap);
+        }
         else
         {
             juce::Font f (juce::FontOptions().withHeight (captionSize * 0.8f));
             auto       w = float (f.getStringWidth (caption));
 
             if (justification.getOnlyHorizontalFlags() & juce::Justification::left)
+            {
                 captionBox = box.removeFromLeft (w).toNearestInt();
+                box.removeFromLeft (captionGap);
+            }
             else if (justification.getOnlyHorizontalFlags() & juce::Justification::right)
+            {
                 captionBox = box.removeFromRight (w).toNearestInt();
+                box.removeFromRight (captionGap);
+            }
         }
     }
 
@@ -181,6 +193,10 @@ void Decorator::configure (MagicGUIBuilder& builder, const juce::ValueTree& node
     auto sizeVar = builder.getStyleProperty (IDs::captionSize, node);
     if (! sizeVar.isVoid())
         captionSize = static_cast<float> (sizeVar);
+
+    auto gapVar = builder.getStyleProperty (IDs::captionGap, node);
+    if (! gapVar.isVoid())
+        captionGap = static_cast<float> (gapVar);
 
     auto placementVar = builder.getStyleProperty (IDs::captionPlacement, node);
     if (! placementVar.isVoid() && placementVar.toString().isNotEmpty())
@@ -220,6 +236,7 @@ void Decorator::reset()
     caption.clear();
     justification = juce::Justification::centredTop;
     captionSize   = 20.0f;
+    captionGap    = 0.0f;
     captionColour = juce::Colours::silver;
 
     tabCaption.clear();

--- a/modules/foleys_gui_magic/Layout/foleys_Decorator.h
+++ b/modules/foleys_gui_magic/Layout/foleys_Decorator.h
@@ -83,6 +83,7 @@ private:
     juce::String        caption;
     juce::Justification justification = juce::Justification::centredTop;
     float               captionSize   = 20.0f;
+    float               captionGap    = 0.0f;
     juce::Colour        captionColour = juce::Colours::silver;
 
     juce::String        tabCaption;


### PR DESCRIPTION
Adds a new 'caption-gap' property that controls the spacing between the caption text and the component content. Works for all caption placements (top, bottom, left, right). Defaults to 0 for backwards compatibility.