### PR TITLE
Fixes the X button in the editor UI's behavior for properties with default values

### DIFF
--- a/modules/foleys_gui_magic/Editor/foleys_StyleTextPropertyComponent.cpp
+++ b/modules/foleys_gui_magic/Editor/foleys_StyleTextPropertyComponent.cpp
@@ -69,11 +69,13 @@ void StyleTextPropertyComponent::refresh()
         if (node == inheritedFrom)
         {
             label->getTextValue().referTo (node.getPropertyAsValue (property, &builder.getUndoManager()));
+            label->setColour (juce::Label::textColourId, EditorColours::text);
         }
         else
         {
             label->getTextValue().referTo (label->getTextValue());
             label->setText (value.toString(), juce::dontSendNotification);
+            label->setColour (juce::Label::textColourId, EditorColours::disabledText);
         }
     }
 


### PR DESCRIPTION
For properties without default values, the X button moves through 3 states, and alwas moves from state 1 towards state 3: 1) Property is set to a value, eg height="7"
2) Property is set to empty string, eg height=""
3) Property is not set at all

This is nice behavior! But it doesn't work that way for properties with default value, like min-width and friends. Those properties just oscillate between states 1 and 2 and can't ever get to 3.

This PR fixes that -- I believe the issue has to do w/ callbacks triggering when we don't want them to.

This PR also makes a UI style change in that for properties in state 3, we grey out the text showing the user what default value is going to be applied. I think this makes it more clear that there is a default, here's what it is, no it's not set in your xml file explicitly. This also applies to values that were inherited -- you can see what's inherited but we make it clear that it's not set on this node.